### PR TITLE
Can apply for a specific meeting

### DIFF
--- a/linku/functional_tests/homepage_test.py
+++ b/linku/functional_tests/homepage_test.py
@@ -1,6 +1,11 @@
+# -*- coding: utf-8 -*-
+
 import sys
 import os
+
 from selenium import webdriver
+from selenium.webdriver.common.alert import Alert
+
 import pytest
 
 
@@ -48,9 +53,7 @@ def test_first_page_cards_title(browser):
 
     # 5,000원~10,000원(가격대)
     assert '5,000원~10,000원' in browser.page_source
-
-    # 그리고 신청하기 버튼이 카드 가장 하단에 있어서,
-    # 한번 눌러보고 싶은 충동이 생겼다.
+    # 들이 보인다.
 
     # 그 바로 하단에는 선이 그어져 있어서 왠지 서로 구분이 되는 느낌이다
     browser.find_element_by_tag_name('hr')
@@ -68,4 +71,42 @@ def test_first_page_cards_title(browser):
     assert '이화여자대학교 10km 이내' in browser.page_source
     # 5,000원~10,000원(가격대)
     assert '5,000원~10,000원' in browser.page_source
-    # 들이 보여졌다.
+    # 들이 보인다.
+
+    # 짱구는 두 모임 중에 지훈이의 '호타루 우동 모임'에 참가하고 싶어졌다.
+    # 그래서 모임 아래에 신청하기 버튼을 확인한 후,
+    btn_list = browser.find_elements_by_tag_name('button')
+    assert btn_list[1].text == "신청하기"
+
+    # 신청 버튼을 눌렀더니
+    btn_list[1].click()
+
+    # 해당 모임을 신청하는 페이지로 이동하였고
+    assert "/meetings/2/apply" in browser.current_url
+
+    # 상단에 "호타루에서 우동 먹을래?" 라는 모임의 제목이 보였다.
+    assert "호타루에서 우동 먹을래?" in browser.page_source
+
+    # 이름, 성별, 연락처를 입력하라는 메세지와 입력박스가 표시된다.
+    assert "이름 : " in browser.page_source
+    assert "연락처 : " in browser.page_source
+    assert "성별 : " in browser.page_source
+
+    input_boxs = browser.find_elements_by_tag_name('input')
+
+    # 그래서 짱구는 이름 칸에 '김짱구'라고 입력 했고
+    input_boxs[0].send_keys('김짱구')
+
+    # 연락처는 '010-1234-5678' 로 입력하고
+    input_boxs[1].send_keys('010-1234-5678')
+
+    # 성별은 '남성'으로 체크하고
+    input_boxs[2].click()
+
+    # 신청 버튼을 누르자
+    apply_button = browser.find_element_by_tag_name('button')
+    apply_button.click()
+
+    # '신청이 완료되었습니다.' 라는 메세지가 표시됐다.
+    assert "신청이완료되었습니다." in Alert(browser).text
+    Alert(browser).accept()

--- a/linku/functional_tests/homepage_test.py
+++ b/linku/functional_tests/homepage_test.py
@@ -39,7 +39,7 @@ def test_first_page_cards_title(browser):
     # 강남(장소)
     assert '강남' in browser.page_source
 
-    # 02/26 20:30 (시작 시간)
+    # 02/22 21:52 (시작 시간)
     assert '02/22 21:52' in browser.page_source
 
     # 규카츠가 맛있게 보이는 사진
@@ -53,12 +53,19 @@ def test_first_page_cards_title(browser):
     # 한번 눌러보고 싶은 충동이 생겼다.
 
     # 그 바로 하단에는 선이 그어져 있어서 왠지 서로 구분이 되는 느낌이다
+    browser.find_element_by_tag_name('hr')
 
     # 맨 상단에는 호타루에서 우동 먹을래? 제목이 보여졌고,
+    assert '호타루에서 우동 먹을래?' in browser.page_source
     # 그 아래에는 최지훈(개설자 이름)
+    assert '최지훈' in browser.page_source
     # 이대(장소)
-    # 02/26 23:30 (시작 시간)
+    assert '이대' in browser.page_source
+    # 02/22 22:22 (시작 시간)
+    assert '02/22 22:22' in browser.page_source
     # 우동이 맛깔스럽게 보이는 사진
     # 이화여자대학교 10km 이내(가까운 대학교와의 거리)
+    assert '이화여자대학교 10km 이내' in browser.page_source
     # 5,000원~10,000원(가격대)
+    assert '5,000원~10,000원' in browser.page_source
     # 들이 보여졌다.

--- a/linku/linku/urls.py
+++ b/linku/linku/urls.py
@@ -19,5 +19,6 @@ from moim import views
 
 urlpatterns = [
     url(r'^$', views.homepage, name='home'),
+    url(r'^meetings/(?P<meeting_id>\d+)/apply/$', views.apply_meeting, name='apply'),
     url(r'^admin/', admin.site.urls),
 ]

--- a/linku/moim/migrations/0003_meeting_initialdata.py
+++ b/linku/moim/migrations/0003_meeting_initialdata.py
@@ -10,8 +10,8 @@ def forwards_func(apps, schema_editor):
     Meeting.objects.using(db_alias).bulk_create([
         Meeting(maker="장선혁", name="규카츠 먹을래?", place="강남", start_time=datetime.datetime(2017, 2, 22, 21, 52, 7, 777885),
                 image_path="", distance_near_univ="고려대학교 10km 이내", price_range="5,000원~10,000원"),
-        Meeting(maker="장선혁", name="우동 먹을래?", place="강남", start_time="2017-02-19T08:09:29Z",
-                image_path="", distance_near_univ="고려대학교 10km 이내", price_range="233000원~335000원"),
+        Meeting(maker="최지훈", name="호타루에서 우동 먹을래?", place="이대", start_time=datetime.datetime(2017, 2, 22, 22, 22, 2, 22),
+                image_path="", distance_near_univ="이화여자대학교 10km 이내", price_range="5,000원~10,000원"),
     ])
 
 

--- a/linku/moim/templates/apply_meeting.html
+++ b/linku/moim/templates/apply_meeting.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Apply Meeting</title>
+</head>
+<body>
+    <h1>{{ meeting.name }}</h1>
+    <form>
+        이름 : <input name="name" type="text"/><br>
+        연락처 : <input name="phone" type="text"/><br>
+        성별 : <input name="gender" type="radio" value="남">남</input>
+        <input name="gender" type="radio" value="여">여</input> <br>
+        <button onclick=alert("신청이완료되었습니다.")>신청</button>
+    </form>
+</body>
+</html>

--- a/linku/moim/templates/meeting_list.html
+++ b/linku/moim/templates/meeting_list.html
@@ -7,6 +7,7 @@
         {{ meeting.start_time|date:"m/d H:i" }} <br>
         {{ meeting.distance_near_univ }} <br>
         {{ meeting.price_range }} <br>
+        <button onclick="location.href='/meetings/{{ meeting.id }}/apply'">신청하기</button><br>
         <hr>
     {% endfor %}
 </body>

--- a/linku/moim/templates/meeting_list.html
+++ b/linku/moim/templates/meeting_list.html
@@ -1,12 +1,13 @@
 <html>
 <body>
     {% for meeting in meetings %}
-        {{ meeting.name }}
-        {{ meeting.maker }}
-        {{ meeting.place }}
-        {{ meeting.start_time|date:"m/d H:i" }}
-        {{ meeting.distance_near_univ }}
-        {{ meeting.price_range }}
+        {{ meeting.name }} <br>
+        {{ meeting.maker }} <br>
+        {{ meeting.place }} <br>
+        {{ meeting.start_time|date:"m/d H:i" }} <br>
+        {{ meeting.distance_near_univ }} <br>
+        {{ meeting.price_range }} <br>
+        <hr>
     {% endfor %}
 </body>
 </html>

--- a/linku/moim/tests.py
+++ b/linku/moim/tests.py
@@ -21,6 +21,29 @@ def test_homepage_use_meeting_list_template(client):
 
 
 @pytest.mark.django_db
+def test_apply_meeting_view_use_correct_template(client):
+    Meeting.objects.create(maker='test maker', name='test name', place='test place',
+                           start_time=datetime.datetime.now(),
+                           distance_near_univ='test distance_near_univ', price_range='test price_range')
+    response_templates = client.get('/meetings/1/apply/').templates
+    assert 'apply_meeting.html' in (
+        template.name for template in response_templates)
+
+
+@pytest.mark.django_db
+def test_apply_meeting_view_return_correct_meeting_name(client):
+    Meeting.objects.create(maker='test maker1', name='test name1', place='test place1',
+                           start_time=datetime.datetime.now(),
+                           distance_near_univ='test distance_near_univ1', price_range='test price_range1')
+    Meeting.objects.create(maker='test maker2', name='test name2', place='test place2',
+                           start_time=datetime.datetime.now(),
+                           distance_near_univ='test distance_near_univ2', price_range='test price_range2')
+    meeting = Meeting.objects.get(maker='test maker2')
+    response = client.get('/meetings/' + str(meeting.id) + '/apply/')
+    assert meeting.name in response.content.decode("utf8")
+
+
+@pytest.mark.django_db
 def test_save_meeting():
     Meeting.objects.create(maker='test maker', name='test name', place='test place',
                            start_time=datetime.datetime.now(),

--- a/linku/moim/tests.py
+++ b/linku/moim/tests.py
@@ -35,7 +35,27 @@ def test_homepage_view_meeting_info(client):
                            start_time=start_time,
                            distance_near_univ='test distance_near_univ', price_range='test price_range')
     response = client.get('/')
+    assert "test maker" in response.content.decode("utf8")
     assert "test name" in response.content.decode("utf8")
+    assert "test place" in response.content.decode("utf8")
+    assert "test distance_near_univ" in response.content.decode("utf8")
+    assert "test price_range" in response.content.decode("utf8")
+
     # template가 포맷에 맞춰 반환하는지 테스트
     assert start_time.strftime(
         '%m/%d %H:%M') in response.content.decode("utf8")
+
+
+@pytest.mark.django_db
+def test_homepage_view_multiple_cards(client):
+    start_time = datetime.datetime.now()
+    Meeting.objects.create(maker='test maker', name='test name1', place='test place',
+                           start_time=start_time,
+                           distance_near_univ='test distance_near_univ', price_range='test price_range')
+    Meeting.objects.create(maker='test maker', name='test name2', place='test place',
+                           start_time=start_time,
+                           distance_near_univ='test distance_near_univ', price_range='test price_range')
+
+    response = client.get('/')
+    assert "test name1" in response.content.decode("utf8")
+    assert "test name2" in response.content.decode("utf8")

--- a/linku/moim/views.py
+++ b/linku/moim/views.py
@@ -6,3 +6,8 @@ from django.shortcuts import render
 def homepage(request):
     meetings = Meeting.objects.all()
     return render(request, 'meeting_list.html', {'meetings': meetings})
+
+
+def apply_meeting(request, meeting_id):
+    meeting = Meeting.objects.get(id=meeting_id)
+    return render(request, 'apply_meeting.html', {'meeting': meeting})


### PR DESCRIPTION
- Add FT, unittest for applying meeting 
- if someone apply for specific meeting, then get meeting_name with meeting_id from DB and show that.
- and applying is completed after input name, phone, gender

### to do.
- need to change using id or class to get element instead of browser.page_source in FT
- refactor separating test 
- save apllier info in DB
